### PR TITLE
Including minimum remain rate limit config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
       name='twilio-tap-zendesk',
-      version='1.0.13',
+      version='1.0.14',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Twilio',
       url='https://github.com/twilio-labs/twilio-tap-zendesk',

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -43,7 +43,7 @@ request = Session.request
 
 
 def request_metrics_patch(self, method, url, **kwargs):
-    with singer_metrics.http_request_timer(None):
+    with singer_metrics.http_request_timer(url):
         response = request(self, method, url, **kwargs)
     rate_throttling(response, parsed_args.config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT))
     return response
@@ -57,7 +57,6 @@ def rate_throttling(response, min_remain_rate_limit):
     if 'x-rate-limit-remaining' in response.headers:
         rate_limit = int(response.headers['x-rate-limit'])
         rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
-        LOGGER.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
         if rate_limit_remain <= min_remain_rate_limit:
             seconds_to_sleep = int(response.headers['rate-limit-reset'])
             LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -252,7 +252,7 @@ def get_session(config):
 @singer.utils.handle_top_exception(LOGGER)
 def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
-    os.environ["TAP_ZENDESK_API_TOKEN"] = str(parsed_args.config.get(("min_remain_rate_limit",
+    os.environ["MIN_REMAIN_RATE_LIMIT"] = str(parsed_args.config.get(("min_remain_rate_limit",
                                                                       DEFAULT_MIN_REMAIN_RATE_LIMIT)))
     # OAuth has precedence
     creds = oauth_auth(parsed_args) or api_token_auth(parsed_args)

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -58,7 +58,7 @@ def calculate_seconds(epoch):
     return int(ceil(epoch - current))
 
 
-def rate_throttling(response, min_remain_rate_limit):
+def rate_throttling(response, min_remain_rate_limit=DEFAULT_MIN_REMAIN_RATE_LIMIT):
     """
     For avoid rate limit issues, get the remaining time before retrying and calculate the time to sleep
     before making a new request.
@@ -252,7 +252,6 @@ def get_session(config):
 @singer.utils.handle_top_exception(LOGGER)
 def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
-    global Session
     Session.request = partial(Session.request,
                               min_remain_rate_limit=parsed_args.config.get("min_remain_rate_limit",
                                                                            DEFAULT_MIN_REMAIN_RATE_LIMIT))

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -4,6 +4,7 @@ import sys
 from json import dump
 from time import sleep
 
+import requests
 import singer
 from requests import Session
 from requests.adapters import HTTPAdapter
@@ -39,8 +40,7 @@ parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
 
 class ZendeskSession(Session):
-    def __init__(self, min_remain_rate_limit, logger):
-        self.logger = logger
+    def __init__(self, min_remain_rate_limit):
         self.min_remain_rate_limit = min_remain_rate_limit
         super().__init__()
 
@@ -59,7 +59,6 @@ class ZendeskSession(Session):
         if 'x-rate-limit-remaining' in response.headers:
             rate_limit = int(response.headers['x-rate-limit'])
             rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
-            self.logger.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
             if rate_limit_remain <= self.min_remain_rate_limit:
                 seconds_to_sleep = int(response.headers['rate-limit-reset'])
                 LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
@@ -230,7 +229,7 @@ def get_session(config):
                                      "marketplace_organization_id",
                                      "marketplace_app_id"]):
         return None
-    session = ZendeskSession(config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT), LOGGER)
+    session = ZendeskSession(config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT))
     # Using Zenpy's default adapter args, following the method outlined here:
     # https://github.com/facetoe/zenpy/blob/master/docs/zenpy.rst#usage
     session.mount("https://", HTTPAdapter(**Zenpy.http_adapter_kwargs()))

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -117,7 +117,7 @@ def validate_dependencies(selected_stream_ids):
 def populate_class_schemas(catalog, selected_stream_names):
     for stream in catalog.streams:
         if stream.tap_stream_id in selected_stream_names:
-            LOGGER.INFO(f"Selected stream: {stream.tap_stream_id}")
+            LOGGER.info(f"Selected stream: {stream.tap_stream_id}")
             STREAMS[stream.tap_stream_id].stream = stream
 
 

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -45,7 +45,7 @@ request = Session.request
 def request_metrics_patch(self, method, url, **kwargs):
     with singer_metrics.http_request_timer(None):
         response = request(self, method, url, **kwargs)
-    print(self.headers)
+    # LOGGER.info(self.headers)
     rate_throttling(response, 600)
     return response
 

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -43,9 +43,9 @@ class ZendeskSession(Session):
         self.min_remain_rate_limit = min_remain_rate_limit
         super().__init__()
 
-    def request(self, method, url, **kwargs):
+    def request(self, url, **kwargs):
         with singer_metrics.http_request_timer(url):
-            response = super().request(method, url, **kwargs)
+            response = super().request(url=url, **kwargs)
         self.rate_throttling(response)
         return response
 
@@ -58,7 +58,7 @@ class ZendeskSession(Session):
         if 'x-rate-limit-remaining' in response.headers:
             rate_limit = int(response.headers['x-rate-limit'])
             rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
-            LOGGER.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {self.min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
+            LOGGER.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
             if rate_limit_remain <= self.min_remain_rate_limit:
                 seconds_to_sleep = int(response.headers['rate-limit-reset'])
                 LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
@@ -67,6 +67,7 @@ class ZendeskSession(Session):
                 sleep(seconds_to_sleep)
         else:
             raise Exception("x-rate-limit-remaining not found in response header")
+        Exception("x-rate-limit-remaining not found in response header")
 
 
 def do_discover(client):

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -45,8 +45,8 @@ request = Session.request
 def request_metrics_patch(self, method, url, **kwargs):
     with singer_metrics.http_request_timer(None):
         response = request(self, method, url, **kwargs)
-    LOGGER.info(self.headers)
-    rate_throttling(response, 600)
+    LOGGER.info(dict(self))
+    rate_throttling(response, 650)
     return response
 
 

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -45,7 +45,8 @@ request = Session.request
 def request_metrics_patch(self, method, url, **kwargs):
     with singer_metrics.http_request_timer(None):
         response = request(self, method, url, **kwargs)
-    rate_throttling(response, self.min_remain_rate_limit)
+    print(self.headers)
+    rate_throttling(response, 600)
     return response
 
 
@@ -245,7 +246,8 @@ def get_session(config):
     session.headers["X-Zendesk-Marketplace-Name"] = config.get("marketplace_name", "")
     session.headers["X-Zendesk-Marketplace-Organization-Id"] = str(config.get("marketplace_organization_id", ""))
     session.headers["X-Zendesk-Marketplace-App-Id"] = str(config.get("marketplace_app_id", ""))
-    session.min_remain_rate_limit = int(config.get(("min_remain_rate_limit", DEFAULT_MIN_REMAIN_RATE_LIMIT)))
+    # session.headers["min_remain_rate_limit"]
+    # session.min_remain_rate_limit = int(config.get(("min_remain_rate_limit", DEFAULT_MIN_REMAIN_RATE_LIMIT)))
     return session
 
 

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-import json
 import os
 import sys
+from json import dump
 from time import sleep
 
-import requests
 import singer
 from requests import Session
 from requests.adapters import HTTPAdapter
@@ -38,43 +37,42 @@ DEFAULT_MIN_REMAIN_RATE_LIMIT = 0
 
 parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
-# patch Session.request to record HTTP request metrics
-request = Session.request
 
+class ZendeskSession(Session):
+    def __init__(self, min_remain_rate_limit):
+        self.min_remain_rate_limit = min_remain_rate_limit
+        super().__init__()
 
-def request_metrics_patch(self, method, url, **kwargs):
-    with singer_metrics.http_request_timer(url):
-        response = request(self, method, url, **kwargs)
-    rate_throttling(response, parsed_args.config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT))
-    return response
+    def request(self, method, url, **kwargs):
+        with singer_metrics.http_request_timer(url):
+            response = super().request(method, url, **kwargs)
+        self.rate_throttling(response)
+        return response
 
+    def rate_throttling(self, response):
+        """
+        To avoid rate limit issues (with concurrent applications), get the remaining time before retrying and
+        calculate the time to sleep before making a new request if the minimum request rate limit remain is below the one
+        defined.
+        """
+        if 'x-rate-limit-remaining' in response.headers:
+            rate_limit = int(response.headers['x-rate-limit'])
+            rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
+            LOGGER.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {self.min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
+            if rate_limit_remain <= self.min_remain_rate_limit:
+                seconds_to_sleep = int(response.headers['rate-limit-reset'])
+                LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
+                            f"min remain limit: {self.min_remain_rate_limit}). "
+                            f"Tap will retry the data collection after {seconds_to_sleep} seconds.")
+                sleep(seconds_to_sleep)
+        else:
+            raise Exception("x-rate-limit-remaining not found in response header")
 
-def rate_throttling(response, min_remain_rate_limit):
-    """
-    To avoid rate limit issues (with concurrent applications), get the remaining time before retrying and
-    calculate the time to sleep before making a new request if the minimum request rate limit remain is below the one
-    defined.
-    """
-    if 'x-rate-limit-remaining' in response.headers:
-        rate_limit = int(response.headers['x-rate-limit'])
-        rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
-        if rate_limit_remain <= min_remain_rate_limit:
-            seconds_to_sleep = int(response.headers['rate-limit-reset'])
-            LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
-                        f"min remain limit: {min_remain_rate_limit}). "
-                        f"Tap will retry the data collection after {seconds_to_sleep} seconds.")
-            sleep(seconds_to_sleep)
-    else:
-        raise Exception("x-rate-limit-remaining not found in response header")
-
-
-Session.request = request_metrics_patch
-# end patch
 
 def do_discover(client):
     LOGGER.info("Starting discover")
     catalog = {"streams": discover_streams(client)}
-    json.dump(catalog, sys.stdout, indent=2)
+    dump(catalog, sys.stdout, indent=2)
     LOGGER.info("Finished discover")
 
 
@@ -231,7 +229,7 @@ def get_session(config):
                                      "marketplace_organization_id",
                                      "marketplace_app_id"]):
         return None
-    session = requests.Session()
+    session = ZendeskSession(config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT))
     # Using Zenpy's default adapter args, following the method outlined here:
     # https://github.com/facetoe/zenpy/blob/master/docs/zenpy.rst#usage
     session.mount("https://", HTTPAdapter(**Zenpy.http_adapter_kwargs()))

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -50,14 +50,6 @@ def request_metrics_patch(self, method, url, **kwargs):
     return response
 
 
-def calculate_seconds(epoch):
-    """
-    Calculate the seconds to sleep before making a new request.
-    """
-    current = time.time()
-    return int(ceil(epoch - current))
-
-
 def rate_throttling(response, min_remain_rate_limit):
     """
     For avoid rate limit issues, get the remaining time before retrying and calculate the time to sleep
@@ -68,7 +60,7 @@ def rate_throttling(response, min_remain_rate_limit):
         rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
         LOGGER.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
         if rate_limit_remain <= min_remain_rate_limit:
-            seconds_to_sleep = calculate_seconds(int(response.headers['rate-limit-reset']))
+            seconds_to_sleep = int(response.headers['rate-limit-reset'])
             LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}). "
                         f"Tap will retry the data collection after {seconds_to_sleep} seconds.")
             sleep(seconds_to_sleep)
@@ -246,7 +238,7 @@ def get_session(config):
     session.headers["X-Zendesk-Marketplace-Name"] = config.get("marketplace_name", "")
     session.headers["X-Zendesk-Marketplace-Organization-Id"] = str(config.get("marketplace_organization_id", ""))
     session.headers["X-Zendesk-Marketplace-App-Id"] = str(config.get("marketplace_app_id", ""))
-    # session.headers["min_remain_rate_limit"]
+    session.headers["min_remain_rate_limit"] = str(config.get(("min_remain_rate_limit", DEFAULT_MIN_REMAIN_RATE_LIMIT)))
     # session.min_remain_rate_limit = int(config.get(("min_remain_rate_limit", DEFAULT_MIN_REMAIN_RATE_LIMIT)))
     return session
 

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -75,6 +75,10 @@ def rate_throttling(response, min_remain_rate_limit):
         raise Exception("x-rate-limit-remaining not found in response header")
 
 
+Session.request = request_metrics_patch
+# end patch
+
+
 def do_discover(client):
     LOGGER.info("Starting discover")
     catalog = {"streams": discover_streams(client)}
@@ -248,7 +252,8 @@ def get_session(config):
 @singer.utils.handle_top_exception(LOGGER)
 def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
-    Session.request = partial(request_metrics_patch,
+    global Session
+    Session.request = partial(Session.request,
                               min_remain_rate_limit=parsed_args.config.get("min_remain_rate_limit",
                                                                            DEFAULT_MIN_REMAIN_RATE_LIMIT))
     # OAuth has precedence

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import json
 import os
 import sys
-from json import dump
 from time import sleep
 
 import requests
@@ -38,41 +38,43 @@ DEFAULT_MIN_REMAIN_RATE_LIMIT = 0
 
 parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
+# patch Session.request to record HTTP request metrics
+request = Session.request
 
-class ZendeskSession(Session):
-    def __init__(self, min_remain_rate_limit):
-        self.min_remain_rate_limit = min_remain_rate_limit
-        super().__init__()
 
-    def request(self, url, **kwargs):
-        with singer_metrics.http_request_timer(url):
-            response = super().request(url=url, **kwargs)
-        self.rate_throttling(response)
-        return response
+def request_metrics_patch(self, method, url, **kwargs):
+    with singer_metrics.http_request_timer(url):
+        response = request(self, method, url, **kwargs)
+    rate_throttling(response, parsed_args.config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT))
+    return response
 
-    def rate_throttling(self, response):
-        """
-        To avoid rate limit issues (with concurrent applications), get the remaining time before retrying and
-        calculate the time to sleep before making a new request if the minimum request rate limit remain is below the one
-        defined.
-        """
-        if 'x-rate-limit-remaining' in response.headers:
-            rate_limit = int(response.headers['x-rate-limit'])
-            rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
-            if rate_limit_remain <= self.min_remain_rate_limit:
-                seconds_to_sleep = int(response.headers['rate-limit-reset'])
-                LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
-                            f"min remain limit: {self.min_remain_rate_limit}). "
-                            f"Tap will retry the data collection after {seconds_to_sleep} seconds.")
-                sleep(seconds_to_sleep)
-        else:
-            raise Exception("x-rate-limit-remaining not found in response header")
 
+def rate_throttling(response, min_remain_rate_limit):
+    """
+    To avoid rate limit issues (with concurrent applications), get the remaining time before retrying and
+    calculate the time to sleep before making a new request if the minimum request rate limit remain is below the one
+    defined.
+    """
+    if 'x-rate-limit-remaining' in response.headers:
+        rate_limit = int(response.headers['x-rate-limit'])
+        rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
+        if rate_limit_remain <= min_remain_rate_limit:
+            seconds_to_sleep = int(response.headers['rate-limit-reset'])
+            LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
+                        f"min remain limit: {min_remain_rate_limit}). "
+                        f"Tap will retry the data collection after {seconds_to_sleep} seconds.")
+            sleep(seconds_to_sleep)
+    else:
+        raise Exception("x-rate-limit-remaining not found in response header")
+
+
+Session.request = request_metrics_patch
+# end patch
 
 def do_discover(client):
     LOGGER.info("Starting discover")
     catalog = {"streams": discover_streams(client)}
-    dump(catalog, sys.stdout, indent=2)
+    json.dump(catalog, sys.stdout, indent=2)
     LOGGER.info("Finished discover")
 
 
@@ -229,7 +231,7 @@ def get_session(config):
                                      "marketplace_organization_id",
                                      "marketplace_app_id"]):
         return None
-    session = ZendeskSession(config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT))
+    session = requests.Session()
     # Using Zenpy's default adapter args, following the method outlined here:
     # https://github.com/facetoe/zenpy/blob/master/docs/zenpy.rst#usage
     session.mount("https://", HTTPAdapter(**Zenpy.http_adapter_kwargs()))

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -40,6 +40,7 @@ parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
 class ZendeskSession(Session):
     def __init__(self, min_remain_rate_limit):
+        self.logger = singer.get_logger()
         self.min_remain_rate_limit = min_remain_rate_limit
         super().__init__()
 
@@ -58,10 +59,10 @@ class ZendeskSession(Session):
         if 'x-rate-limit-remaining' in response.headers:
             rate_limit = int(response.headers['x-rate-limit'])
             rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
-            LOGGER.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {self.min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
+            self.logger.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {self.min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
             if rate_limit_remain <= self.min_remain_rate_limit:
                 seconds_to_sleep = int(response.headers['rate-limit-reset'])
-                LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
+                self.logger.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
                             f"min remain limit: {self.min_remain_rate_limit}). "
                             f"Tap will retry the data collection after {seconds_to_sleep} seconds.")
                 sleep(seconds_to_sleep)

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -39,8 +39,7 @@ parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
 
 class ZendeskSession(Session):
-    def __init__(self, min_remain_rate_limit, logger):
-        self.logger = logger
+    def __init__(self, min_remain_rate_limit):
         self.min_remain_rate_limit = min_remain_rate_limit
         super().__init__()
 
@@ -59,7 +58,7 @@ class ZendeskSession(Session):
         if 'x-rate-limit-remaining' in response.headers:
             rate_limit = int(response.headers['x-rate-limit'])
             rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
-            self.logger.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
+            LOGGER.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
             if rate_limit_remain <= self.min_remain_rate_limit:
                 seconds_to_sleep = int(response.headers['rate-limit-reset'])
                 LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
@@ -68,6 +67,7 @@ class ZendeskSession(Session):
                 sleep(seconds_to_sleep)
         else:
             raise Exception("x-rate-limit-remaining not found in response header")
+        Exception("x-rate-limit-remaining not found in response header")
 
 
 def do_discover(client):
@@ -230,7 +230,7 @@ def get_session(config):
                                      "marketplace_organization_id",
                                      "marketplace_app_id"]):
         return None
-    session = ZendeskSession(config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT), LOGGER)
+    session = ZendeskSession(config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT))
     # Using Zenpy's default adapter args, following the method outlined here:
     # https://github.com/facetoe/zenpy/blob/master/docs/zenpy.rst#usage
     session.mount("https://", HTTPAdapter(**Zenpy.http_adapter_kwargs()))

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -2,8 +2,6 @@
 import json
 import os
 import sys
-import time
-from math import ceil
 from time import sleep
 
 import requests
@@ -57,7 +55,6 @@ def rate_throttling(response, min_remain_rate_limit):
     if 'x-rate-limit-remaining' in response.headers:
         rate_limit = int(response.headers['x-rate-limit'])
         rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
-        LOGGER.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
         if rate_limit_remain <= min_remain_rate_limit:
             seconds_to_sleep = int(response.headers['rate-limit-reset'])
             LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
@@ -68,7 +65,7 @@ def rate_throttling(response, min_remain_rate_limit):
         raise Exception("x-rate-limit-remaining not found in response header")
 
 
-# Session.request = request_metrics_patch
+Session.request = request_metrics_patch
 # end patch
 
 def do_discover(client):
@@ -231,7 +228,6 @@ def get_session(config):
                                      "marketplace_organization_id",
                                      "marketplace_app_id"]):
         return None
-    Session.request = request_metrics_patch
     session = requests.Session()
     # Using Zenpy's default adapter args, following the method outlined here:
     # https://github.com/facetoe/zenpy/blob/master/docs/zenpy.rst#usage

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -2,7 +2,7 @@
 import json
 import os
 import sys
-from datetime import time
+import time
 from math import ceil
 from time import sleep
 
@@ -45,7 +45,7 @@ request = Session.request
 def request_metrics_patch(self, method, url, **kwargs):
     with singer_metrics.http_request_timer(None):
         response = request(self, method, url, **kwargs)
-    # LOGGER.info(self.headers)
+    LOGGER.info(self.headers)
     rate_throttling(response, 600)
     return response
 
@@ -54,7 +54,7 @@ def calculate_seconds(epoch):
     """
     Calculate the seconds to sleep before making a new request.
     """
-    current = time()
+    current = time.time()
     return int(ceil(epoch - current))
 
 
@@ -66,7 +66,7 @@ def rate_throttling(response, min_remain_rate_limit):
     if 'x-rate-limit-remaining' in response.headers:
         rate_limit = int(response.headers['x-rate-limit'])
         rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
-        LOGGER.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {min_remain_rate_limit}')
+        LOGGER.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
         if rate_limit_remain <= min_remain_rate_limit:
             seconds_to_sleep = calculate_seconds(int(response.headers['rate-limit-reset']))
             LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}). "

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -46,8 +46,8 @@ request = Session.request
 def request_metrics_patch(self, method, url, min_remain_rate_limit=DEFAULT_MIN_REMAIN_RATE_LIMIT, **kwargs):
     with singer_metrics.http_request_timer(None):
         response = request(self, method, url, **kwargs)
-        LOGGER.info(response.headers)
-        return rate_throttling(response, min_remain_rate_limit)
+        rate_throttling(response, min_remain_rate_limit)
+        return response
 
 
 def calculate_seconds(epoch):

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -66,6 +66,7 @@ def rate_throttling(response, min_remain_rate_limit):
     if 'x-rate-limit-remaining' in response.headers:
         rate_limit = int(response.headers['x-rate-limit'])
         rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
+        LOGGER.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {min_remain_rate_limit}')
         if rate_limit_remain <= min_remain_rate_limit:
             seconds_to_sleep = calculate_seconds(int(response.headers['rate-limit-reset']))
             LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}). "

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -45,7 +45,7 @@ request = Session.request
 def request_metrics_patch(self, method, url, **kwargs):
     with singer_metrics.http_request_timer(None):
         response = request(self, method, url, **kwargs)
-    LOGGER.info(dict(self))
+    LOGGER.info(dir(self))
     rate_throttling(response, 650)
     return response
 

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -117,6 +117,7 @@ def validate_dependencies(selected_stream_ids):
 def populate_class_schemas(catalog, selected_stream_names):
     for stream in catalog.streams:
         if stream.tap_stream_id in selected_stream_names:
+            LOGGER.INFO(f"Selected stream: {stream.tap_stream_id}")
             STREAMS[stream.tap_stream_id].stream = stream
 
 

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -38,7 +38,7 @@ request = Session.request
 def request_metrics_patch(self, method, url, **kwargs):
     with singer_metrics.http_request_timer(None):
         response = request(self, method, url, **kwargs)
-        print(response.headers)
+        LOGGER.info(response.headers)
         return response
 
 Session.request = request_metrics_patch

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -37,7 +37,9 @@ request = Session.request
 
 def request_metrics_patch(self, method, url, **kwargs):
     with singer_metrics.http_request_timer(None):
-        return request(self, method, url, **kwargs)
+        response = request(self, method, url, **kwargs)
+        print(response.headers)
+        return response
 
 Session.request = request_metrics_patch
 # end patch
@@ -117,7 +119,6 @@ def validate_dependencies(selected_stream_ids):
 def populate_class_schemas(catalog, selected_stream_names):
     for stream in catalog.streams:
         if stream.tap_stream_id in selected_stream_names:
-            LOGGER.info(f"Selected stream: {stream.tap_stream_id}")
             STREAMS[stream.tap_stream_id].stream = stream
 
 

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-import json
 import os
 import sys
+from json import dump
 from time import sleep
 
 import requests
@@ -38,43 +38,41 @@ DEFAULT_MIN_REMAIN_RATE_LIMIT = 0
 
 parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
-# patch Session.request to record HTTP request metrics
-request = Session.request
 
+class ZendeskSession(Session):
+    def __init__(self, min_remain_rate_limit):
+        self.min_remain_rate_limit = min_remain_rate_limit
+        super().__init__()
 
-def request_metrics_patch(self, method, url, **kwargs):
-    with singer_metrics.http_request_timer(url):
-        response = request(self, method, url, **kwargs)
-    rate_throttling(response, parsed_args.config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT))
-    return response
+    def request(self, url, **kwargs):
+        with singer_metrics.http_request_timer(url):
+            response = super().request(url=url, **kwargs)
+        self.rate_throttling(response)
+        return response
 
+    def rate_throttling(self, response):
+        """
+        To avoid rate limit issues (with concurrent applications), get the remaining time before retrying and
+        calculate the time to sleep before making a new request if the minimum request rate limit remain is below the one
+        defined.
+        """
+        if 'x-rate-limit-remaining' in response.headers:
+            rate_limit = int(response.headers['x-rate-limit'])
+            rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
+            if rate_limit_remain <= self.min_remain_rate_limit:
+                seconds_to_sleep = int(response.headers['rate-limit-reset'])
+                LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
+                            f"min remain limit: {self.min_remain_rate_limit}). "
+                            f"Tap will retry the data collection after {seconds_to_sleep} seconds.")
+                sleep(seconds_to_sleep)
+        else:
+            raise Exception("x-rate-limit-remaining not found in response header")
 
-def rate_throttling(response, min_remain_rate_limit):
-    """
-    To avoid rate limit issues (with concurrent applications), get the remaining time before retrying and
-    calculate the time to sleep before making a new request if the minimum request rate limit remain is below the one
-    defined.
-    """
-    if 'x-rate-limit-remaining' in response.headers:
-        rate_limit = int(response.headers['x-rate-limit'])
-        rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
-        if rate_limit_remain <= min_remain_rate_limit:
-            seconds_to_sleep = int(response.headers['rate-limit-reset'])
-            LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
-                        f"min remain limit: {min_remain_rate_limit}). "
-                        f"Tap will retry the data collection after {seconds_to_sleep} seconds.")
-            sleep(seconds_to_sleep)
-    else:
-        raise Exception("x-rate-limit-remaining not found in response header")
-
-
-Session.request = request_metrics_patch
-# end patch
 
 def do_discover(client):
     LOGGER.info("Starting discover")
     catalog = {"streams": discover_streams(client)}
-    json.dump(catalog, sys.stdout, indent=2)
+    dump(catalog, sys.stdout, indent=2)
     LOGGER.info("Finished discover")
 
 
@@ -231,7 +229,7 @@ def get_session(config):
                                      "marketplace_organization_id",
                                      "marketplace_app_id"]):
         return None
-    session = requests.Session()
+    session = ZendeskSession(config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT))
     # Using Zenpy's default adapter args, following the method outlined here:
     # https://github.com/facetoe/zenpy/blob/master/docs/zenpy.rst#usage
     session.mount("https://", HTTPAdapter(**Zenpy.http_adapter_kwargs()))

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -39,7 +39,8 @@ parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
 
 class ZendeskSession(Session):
-    def __init__(self, min_remain_rate_limit):
+    def __init__(self, min_remain_rate_limit, logger):
+        self.logger = logger
         self.min_remain_rate_limit = min_remain_rate_limit
         super().__init__()
 
@@ -58,7 +59,7 @@ class ZendeskSession(Session):
         if 'x-rate-limit-remaining' in response.headers:
             rate_limit = int(response.headers['x-rate-limit'])
             rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
-            LOGGER.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
+            self.logger.info(f'x-rate-limit-remaining: {rate_limit_remain} | x-rate-limit: {rate_limit} | min_remain_rate_limit: {min_remain_rate_limit} | rate-limit-reset: {response.headers["rate-limit-reset"]}')
             if rate_limit_remain <= self.min_remain_rate_limit:
                 seconds_to_sleep = int(response.headers['rate-limit-reset'])
                 LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
@@ -67,7 +68,6 @@ class ZendeskSession(Session):
                 sleep(seconds_to_sleep)
         else:
             raise Exception("x-rate-limit-remaining not found in response header")
-        Exception("x-rate-limit-remaining not found in response header")
 
 
 def do_discover(client):
@@ -230,7 +230,7 @@ def get_session(config):
                                      "marketplace_organization_id",
                                      "marketplace_app_id"]):
         return None
-    session = ZendeskSession(config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT))
+    session = ZendeskSession(config.get('min_remain_rate_limit', DEFAULT_MIN_REMAIN_RATE_LIMIT), LOGGER)
     # Using Zenpy's default adapter args, following the method outlined here:
     # https://github.com/facetoe/zenpy/blob/master/docs/zenpy.rst#usage
     session.mount("https://", HTTPAdapter(**Zenpy.http_adapter_kwargs()))

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -51,8 +51,9 @@ def request_metrics_patch(self, method, url, **kwargs):
 
 def rate_throttling(response, min_remain_rate_limit):
     """
-    For avoid rate limit issues, get the remaining time before retrying and calculate the time to sleep
-    before making a new request.
+    To avoid rate limit issues (with concurrent applications), get the remaining time before retrying and
+    calculate the time to sleep before making a new request if the minimum request rate limit remain is below the one
+    defined.
     """
     if 'x-rate-limit-remaining' in response.headers:
         rate_limit = int(response.headers['x-rate-limit'])

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -1,7 +1,6 @@
 import os
 import json
 import datetime
-import time
 import pytz
 import zenpy
 from zenpy.lib.exception import RecordNotFoundException


### PR DESCRIPTION
# Description of change
When the Zendesk API request rate limit is shared with different applications, using all the limits available could impact the correct behavior of these applications. So this PR includes a configurable parameter that sets a soft limit for the remains request rate limit and avoids consuming all request rate limits available.

# Manual QA steps
 - Executed the extractor with a high `min_remain_rate_limit` of almost the rate limit available (e.g. 630 if the rate limit is 700)
 - Ran the extractor and checked the log to verify if the reset time is being respected.
```
2022-12-20T21:42:38.729545Z [info     ] time=2022-12-20 18:42:38 name=singer level=INFO message=METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.31553101539611816, "tags": {"endpoint": "https://woothemes.zendesk.com/api/v2/tickets/5805588/metrics.json", "status": "succeeded"}} cmd_type=extractor name=tap-zendesk run_id=97154896-0092-4a8e-8390-63d337f5bac6 state_id=2022-12-20T214210--tap-zendesk--target-jsonl stdio=stderr
2022-12-20T21:42:38.729954Z [info     ] time=2022-12-20 18:42:38 name=singer level=INFO message=API rate limit exceeded (rate limit: 700, remain: 630, min remain limit: 630). Tap will retry the data collection after 22 seconds. cmd_type=extractor name=tap-zendesk run_id=97154896-0092-4a8e-8390-63d337f5bac6 state_id=2022-12-20T214210--tap-zendesk--target-jsonl stdio=stderr
2022-12-20T21:43:01.117622Z [info     ] time=2022-12-20 18:43:01 name=singer level=INFO message=METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.37802696228027344, "tags": {"endpoint": "https://woothemes.zendesk.com/api/v2/tickets/5796575/metrics.json", "status": "succeeded"}} cmd_type=extractor name=tap-zendesk run_id=97154896-0092-4a8e-8390-63d337f5bac6 state_id=2022-12-20T214210--tap-zendesk--target-jsonl stdio=stderr
``` 
# Risks
 - 
 
# Rollback steps
 - revert this branch
