### PR TITLE
Fix ticket audit schema with missing type for metadata.custom field

### DIFF
--- a/tap_zendesk/schemas/ticket_audits.json
+++ b/tap_zendesk/schemas/ticket_audits.json
@@ -505,7 +505,11 @@
         "object"
       ],
       "properties": {
-        "custom": {},
+        "custom": {
+          "type": [
+            "null"
+          ]
+        },
         "trusted": {
           "type": [
             "null",

--- a/tap_zendesk/schemas/ticket_audits.json
+++ b/tap_zendesk/schemas/ticket_audits.json
@@ -508,7 +508,7 @@
         "custom": {
           "type": [
             "null",
-            "string"
+            "object"
           ]
         },
         "trusted": {

--- a/tap_zendesk/schemas/ticket_audits.json
+++ b/tap_zendesk/schemas/ticket_audits.json
@@ -508,7 +508,7 @@
         "custom": {
           "type": [
             "null",
-            "object"
+            "string"
           ]
         },
         "trusted": {

--- a/tap_zendesk/schemas/ticket_audits.json
+++ b/tap_zendesk/schemas/ticket_audits.json
@@ -507,7 +507,8 @@
       "properties": {
         "custom": {
           "type": [
-            "null"
+            "null",
+            "string"
           ]
         },
         "trusted": {


### PR DESCRIPTION
# Description of change
The `metadata.custom` field doesn't have the type defined which causes some exceptions when used with some targets (e.g. [target-hdfs](https://github.com/Automattic/target-hdfs)).

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
