### PR TITLE
Including param to set incremental extraction to time-based approach (default) or cursor-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ For a simplified, but less granular setup, you can use the API Token authenticat
   "email": "user@domain.com",
   "api_token": "THISISAVERYLONGTOKEN",
   "subdomain": "acme",
-  "start_date": "2000-01-01T00:00:00Z"
+  "start_date": "2000-01-01T00:00:00Z",
+  "ticket_paginate_by_time": false
 }
 ```
 
@@ -43,6 +44,10 @@ An optional `end_date` field can be added to the `config.json`
 This functionality has been added to ease the backfill procedure for a limited time duration for Zendesk
 
 If passed, data would be loaded for `date >= start_date and date < end_date`
+
+The `ticket_paginate_by_time` field is optional and defaults to `true` (time-based approach). 
+If set to `false`, the tap will paginate tickets by cursor-based instead of time-based. 
+This is useful if you are getting timeout on server side because too many updates in the same time range.
 
 ### Sideloading for tickets
 

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -65,8 +65,7 @@ def rate_throttling(response, min_remain_rate_limit):
                         f"Tap will retry the data collection after {seconds_to_sleep} seconds.")
             sleep(seconds_to_sleep)
     else:
-        LOGGER.warn("x-rate-limit-remaining not found in response header. Sleeping for 30 seconds.")
-        sleep(30)
+        raise Exception("x-rate-limit-remaining not found in response header")
 
 
 Session.request = request_metrics_patch

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -65,7 +65,8 @@ def rate_throttling(response, min_remain_rate_limit):
                         f"Tap will retry the data collection after {seconds_to_sleep} seconds.")
             sleep(seconds_to_sleep)
     else:
-        raise Exception("x-rate-limit-remaining not found in response header")
+        LOGGER.warn("x-rate-limit-remaining not found in response header. Sleeping for 30 seconds.")
+        sleep(30)
 
 
 Session.request = request_metrics_patch

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -243,7 +243,7 @@ class Tickets(Stream):
     def sync(self, state):
         bookmark = self.get_bookmark(state)
         sideload_objects = get_sideload_objects(self.stream)
-        tickets = self.client.tickets.incremental(start_time=bookmark, include=sideload_objects)
+        tickets = self.client.tickets.incremental.cursor_start(start_time=bookmark, include=sideload_objects)
         audits_stream = TicketAudits(self.client)
         metrics_stream = TicketMetrics(self.client)
         comments_stream = TicketComments(self.client)

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -242,9 +242,10 @@ class Tickets(Stream):
 
     def sync(self, state):
         bookmark = self.get_bookmark(state)
+        ticket_paginate_by_time = self.config.get('ticket_paginate_by_time', True)
         sideload_objects = get_sideload_objects(self.stream)
         tickets = self.client.tickets.incremental(start_time=bookmark, include=sideload_objects,
-                                                  paginate_by_time=False, per_page=500)
+                                                  paginate_by_time=ticket_paginate_by_time, per_page=500)
         audits_stream = TicketAudits(self.client)
         metrics_stream = TicketMetrics(self.client)
         comments_stream = TicketComments(self.client)

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -243,8 +243,8 @@ class Tickets(Stream):
     def sync(self, state):
         bookmark = self.get_bookmark(state)
         sideload_objects = get_sideload_objects(self.stream)
-        tickets = self.client.tickets.incremental.cursor_start(start_time=bookmark, include=sideload_objects,
-                                                               per_page=500)
+        tickets = self.client.tickets.incremental(start_time=bookmark, include=sideload_objects,
+                                                  paginate_by_time=False, per_page=500)
         audits_stream = TicketAudits(self.client)
         metrics_stream = TicketMetrics(self.client)
         comments_stream = TicketComments(self.client)

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -243,7 +243,8 @@ class Tickets(Stream):
     def sync(self, state):
         bookmark = self.get_bookmark(state)
         sideload_objects = get_sideload_objects(self.stream)
-        tickets = self.client.tickets.incremental.cursor_start(start_time=bookmark, include=sideload_objects)
+        tickets = self.client.tickets.incremental.cursor_start(start_time=bookmark, include=sideload_objects,
+                                                               per_page=500)
         audits_stream = TicketAudits(self.client)
         metrics_stream = TicketMetrics(self.client)
         comments_stream = TicketComments(self.client)


### PR DESCRIPTION
If a request is getting timeout (server-side) because of too many updates at the same time range, the per_page option needs to be defined (which is only available in cursor-based approach). And the cursor based approach is also recommended by Zendesk:
> Cursor-based exports are highly encouraged because they provide more consistent performance and response body sizes.
https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/#incremental-ticket-export-cursor-based

# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
