### PR TITLE
Fixing field with no type in ticket_comments schema (metadata > custom)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ config.json
 .autoenv.zsh
 
 *~
+/catalog.json

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
       name='twilio-tap-zendesk',
-      version='1.0.14',
+      version='1.0.16',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Twilio',
       url='https://github.com/twilio-labs/twilio-tap-zendesk',

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
       install_requires=[
           'pipelinewise-singer-python==1.2.0',
           'zenpy==2.0.25',
+          'requests==2.20.0"
       ],
       extras_require={
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
       install_requires=[
           'pipelinewise-singer-python==1.2.0',
           'zenpy==2.0.25',
-          'requests==2.20.0"
+          'requests==2.20.0'
       ],
       extras_require={
           'dev': [

--- a/tap_zendesk/schemas/shared/metadata.json
+++ b/tap_zendesk/schemas/shared/metadata.json
@@ -4,7 +4,12 @@
     "object"
   ],
   "properties": {
-    "custom": {},
+    "custom": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "trusted": {
       "type": [
         "null",


### PR DESCRIPTION
# Description of change
This PR includes the `metadata > custom` field type. Without the type, the `ticket_comments` scheme may fail if the loader checks the field type.

# Manual QA steps
 - Tested with `target-hdfs` loader.
- ` tap-zendesk --config config.json --discover > ./catalog.json `
<img width="478" alt="image" src="https://github.com/Automattic/tap-zendesk/assets/7281460/a9ca0374-2353-4cda-ba29-c2f05f6771ca">

 
# Risks
 - 
 
# Rollback steps
 - revert this branch
