### PR TITLE
Add a default time to sleep in case the `rate-limit-reset` is not provided

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
       py_modules=['tap_zendesk'],
       install_requires=[
           'pipelinewise-singer-python==1.2.0',
-          'zenpy==2.0.25',
+          'zenpy==2.0.46',
           'requests==2.20.0'
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
       py_modules=['tap_zendesk'],
       install_requires=[
           'pipelinewise-singer-python==1.2.0',
-          'zenpy==2.0.46',
+          'zenpy==2.0.25',
           'requests==2.20.0'
       ],
       extras_require={

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -55,11 +55,11 @@ def rate_throttling(response, min_remain_rate_limit):
     calculate the time to sleep before making a new request if the minimum request rate limit remain is below the one
     defined.
     """
+    LOGGER.info(f'Response headers: {response.headers}')
     if 'x-rate-limit-remaining' in response.headers:
         rate_limit = int(response.headers['x-rate-limit'])
         rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
         if rate_limit_remain <= min_remain_rate_limit:
-            LOGGER.info(f'Response headers: {response.headers}')
             seconds_to_sleep = int(response.headers.get('rate-limit-reset', 60))
             LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
                         f"min remain limit: {min_remain_rate_limit}). "

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -59,7 +59,7 @@ def rate_throttling(response, min_remain_rate_limit):
         rate_limit = int(response.headers['x-rate-limit'])
         rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
         if rate_limit_remain <= min_remain_rate_limit:
-            LOGGER.info(response.headers)
+            LOGGER.info(f'Response headers: {response.headers}')
             seconds_to_sleep = int(response.headers.get('rate-limit-reset', 60))
             LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
                         f"min remain limit: {min_remain_rate_limit}). "

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -59,7 +59,7 @@ def rate_throttling(response, min_remain_rate_limit):
         rate_limit = int(response.headers['x-rate-limit'])
         rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
         if rate_limit_remain <= min_remain_rate_limit:
-            seconds_to_sleep = int(response.headers['rate-limit-reset'])
+            seconds_to_sleep = int(response.headers.get('rate-limit-reset', 60))
             LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
                         f"min remain limit: {min_remain_rate_limit}). "
                         f"Tap will retry the data collection after {seconds_to_sleep} seconds.")

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -67,7 +67,7 @@ def rate_throttling(response, min_remain_rate_limit):
                         f"Tap will retry the data collection after {seconds_to_sleep} seconds.")
             sleep(seconds_to_sleep)
     else:
-        raise Exception("rate-limit-remaining not found in response header")
+        raise Exception(f"rate-limit-remaining not found in response header: {headers}")
 
 
 Session.request = request_metrics_patch

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -55,12 +55,13 @@ def rate_throttling(response, min_remain_rate_limit):
     calculate the time to sleep before making a new request if the minimum request rate limit remain is below the one
     defined.
     """
-    rate_limit_remain = response.headers.get('x-rate-limit-remaining', response.headers.get('ratelimit-remaining'))
+    headers = response.headers
+    rate_limit_remain = headers.get('x-rate-limit-remaining', headers.get('ratelimit-remaining'))
     if rate_limit_remain:
         rate_limit_remain = int(rate_limit_remain)
-        rate_limit = int(response.headers.get('x-rate-limit', response.headers.get('ratelimit-limit')))
+        rate_limit = int(headers.get('x-rate-limit', headers.get('ratelimit-limit')))
         if rate_limit_remain <= min_remain_rate_limit:
-            seconds_to_sleep = int(response.headers.get('rate-limit-reset', response.headers.get('ratelimit-reset', 60)))
+            seconds_to_sleep = int(headers.get('rate-limit-reset', headers.get('ratelimit-reset', 60)))
             LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
                         f"min remain limit: {min_remain_rate_limit}). "
                         f"Tap will retry the data collection after {seconds_to_sleep} seconds.")

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -65,8 +65,8 @@ def rate_throttling(response, min_remain_rate_limit):
                         f"min remain limit: {min_remain_rate_limit}). "
                         f"Tap will retry the data collection after {seconds_to_sleep} seconds.")
             sleep(seconds_to_sleep)
-    else:
-        raise Exception("x-rate-limit-remaining not found in response header")
+    # else:
+    #     raise Exception("x-rate-limit-remaining not found in response header")
 
 
 Session.request = request_metrics_patch

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -59,6 +59,7 @@ def rate_throttling(response, min_remain_rate_limit):
         rate_limit = int(response.headers['x-rate-limit'])
         rate_limit_remain = int(response.headers['x-rate-limit-remaining'])
         if rate_limit_remain <= min_remain_rate_limit:
+            LOGGER.info(response.headers)
             seconds_to_sleep = int(response.headers.get('rate-limit-reset', 60))
             LOGGER.info(f"API rate limit exceeded (rate limit: {rate_limit}, remain: {rate_limit_remain}, "
                         f"min remain limit: {min_remain_rate_limit}). "


### PR DESCRIPTION
# Description of change
The rate limit resets every 60 seconds, but sometimes the `rate-limit-reset` is not provided in the header, breaking the code.

So this PR adds a default time to reset of 60 seconds in case `rate-limit-reset` is not provided and also check other params that is being returned in the response header.

```
'x-rate-limit': '700', 'ratelimit-limit': '700', 'x-rate-limit-remaining': '667', 'ratelimit-remaining': '667', 'ratelimit-reset': '50'
```

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
